### PR TITLE
Alter URL match

### DIFF
--- a/goopy custom pfp for all roblox-0.8.user.js
+++ b/goopy custom pfp for all roblox-0.8.user.js
@@ -4,7 +4,7 @@
 // @version      0.8
 // @description  balls
 // @author       goose
-// @match        https://www.roblox.com/users/*
+// @match        https://www.google.com/
 // @grant        GM_getValue
 // @grant        GM_setValue
 // @run-at       document-idle


### PR DESCRIPTION
Alter the URL match so that it is `google.com` instead of `roblox.com`, which will cause the script to break.